### PR TITLE
OPSIM-1171: Fix link to Document 20160

### DIFF
--- a/index.md
+++ b/index.md
@@ -128,8 +128,8 @@ of the LSST mirors and focal plane and atmosphere, as well as
 observations from existing telescopes, indicate that the PSF for point
 sources should be similar to a von Karman profile. The details of the profile
 depend independently on the size of the atmospheric IQ and the
-hardware IQ. The conversion factors are described in the `Document 20160 <http://ls.st/document-20610>_`
-by Bo Xin and Zeljko Ivezic.
+hardware IQ. The conversion factors are described in the [Document 20160](http://ls.st/document-20160)
+by Bo Xin, George Angeli, and Zeljko Ivezic.
 
 Because the SNR calculation only depends on the number of pixels
 contained in the footprint on the focal plane (to determine the sky

--- a/index.md
+++ b/index.md
@@ -335,7 +335,7 @@ Official project documents not under change control -
 
 ```{eval-rst}
 +---------------------------------------------------------+--------+------------------------------------------------------+
-|Primary mirror clear aperture [#areanote]_               | 6.423 m| LSE-29, LSR-REQ-0003, LSST Key Numbers               |
+|Primary mirror clear aperture [^areanote]                | 6.423 m| LSE-29, LSR-REQ-0003, LSST Key Numbers               |
 +---------------------------------------------------------+--------+------------------------------------------------------+
 |Total instrumental noise per exposure                    | 9 e-   | LSE-59, CAM-REQ-0020 (readnoise and dark current)    |
 +---------------------------------------------------------+--------+------------------------------------------------------+


### PR DESCRIPTION
This fixes the link to Document 20160 as well as the link format and author attribution.